### PR TITLE
feat: centralize server env config

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -1,0 +1,14 @@
+import 'dotenv/config';
+
+function getEnvVar(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Environment variable ${name} is required`);
+  }
+  return value;
+}
+
+export const SUPABASE_URL = getEnvVar('SUPABASE_URL');
+export const DANIEL_SUPABASE_ANON_KEY = getEnvVar('DANIEL_SUPABASE_ANON_KEY');
+export const DATABASE_URL = getEnvVar('DATABASE_URL');
+

--- a/server/db.ts
+++ b/server/db.ts
@@ -2,6 +2,7 @@ import { Pool, neonConfig } from '@neondatabase/serverless';
 import { drizzle } from 'drizzle-orm/neon-serverless';
 import ws from "ws";
 import * as schema from "@shared/schema";
+import { DATABASE_URL } from './config';
 
 // Configure Neon with WebSocket constructor
 neonConfig.webSocketConstructor = ws;
@@ -10,15 +11,9 @@ neonConfig.webSocketConstructor = ws;
 neonConfig.poolQueryViaFetch = true;
 neonConfig.useSecureWebSocket = true;
 
-if (!process.env.DATABASE_URL) {
-  throw new Error(
-    "DATABASE_URL must be set. Did you forget to provision a database?",
-  );
-}
-
 // Create pool with better connection handling
-export const pool = new Pool({ 
-  connectionString: process.env.DATABASE_URL,
+export const pool = new Pool({
+  connectionString: DATABASE_URL,
   max: 10,
   idleTimeoutMillis: 30000,
   connectionTimeoutMillis: 10000,

--- a/server/direct-supabase-sync.ts
+++ b/server/direct-supabase-sync.ts
@@ -3,6 +3,8 @@
  * Syncs authentic photos from Daniel's Supabase database directly to local database
  */
 
+import { SUPABASE_URL, DANIEL_SUPABASE_ANON_KEY, DATABASE_URL } from './config';
+
 interface SupabaseDestination {
   destination_id: number;
   name: string;
@@ -20,15 +22,15 @@ export class DirectSupabaseSync {
 
   async initializeConnections() {
     // Initialize Supabase connection to Daniel's database
-    const { createClient } = await import('@supabase/supabase-js');
-    this.supabase = createClient(
-      process.env.SUPABASE_URL!,
-      process.env.DANIEL_SUPABASE_ANON_KEY!
-    );
+      const { createClient } = await import('@supabase/supabase-js');
+      this.supabase = createClient(
+        SUPABASE_URL,
+        DANIEL_SUPABASE_ANON_KEY
+      );
 
     // Initialize local database connection
-    const { neon } = await import('@neondatabase/serverless');
-    this.localDb = neon(process.env.DATABASE_URL!);
+      const { neon } = await import('@neondatabase/serverless');
+      this.localDb = neon(DATABASE_URL);
   }
 
   async syncPhotosFromSupabase(limit?: number): Promise<{

--- a/server/google-places-authentic-sync.ts
+++ b/server/google-places-authentic-sync.ts
@@ -3,6 +3,8 @@
  * Gets real, authentic photos for each destination using Google Places API
  */
 
+import { DATABASE_URL } from './config';
+
 export class GooglePlacesAuthenticSync {
   private localDb: any;
   private processed: number = 0;
@@ -19,7 +21,7 @@ export class GooglePlacesAuthenticSync {
 
   async initializeConnection() {
     const { neon } = await import('@neondatabase/serverless');
-    this.localDb = neon(process.env.DATABASE_URL!);
+    this.localDb = neon(DATABASE_URL);
   }
 
   async syncAuthenticDestinationPhotos(limit?: number): Promise<{

--- a/server/google-places-complete-sync.ts
+++ b/server/google-places-complete-sync.ts
@@ -1,7 +1,9 @@
 /**
  * Complete Google Places Photo Sync System
  * CRITICAL MISSION: Get authentic photos for EVERY destination
- */
+*/
+
+import { DATABASE_URL } from './config';
 
 interface SyncResult {
   destinationId: string;
@@ -29,7 +31,7 @@ export class GooglePlacesCompleteSync {
 
   async initializeConnection() {
     const { neon } = await import('@neondatabase/serverless');
-    this.localDb = neon(process.env.DATABASE_URL!);
+    this.localDb = neon(DATABASE_URL);
   }
 
   async syncAllDestinationPhotos(): Promise<{

--- a/server/google-places-photo-sync.ts
+++ b/server/google-places-photo-sync.ts
@@ -3,6 +3,8 @@
  * Syncs authentic photos from Google Places API to Supabase cover_photo_url field
  */
 
+import { SUPABASE_URL, DANIEL_SUPABASE_ANON_KEY } from './config';
+
 interface GooglePlacesResponse {
   candidates: Array<{
     place_id: string;
@@ -57,13 +59,13 @@ export class GooglePlacesPhotoSync {
     throw new Error('No Google Places API key found in environment variables');
   }
 
-  async initializeSupabase() {
-    const { createClient } = await import('@supabase/supabase-js');
-    this.supabase = createClient(
-      process.env.SUPABASE_URL!,
-      process.env.DANIEL_SUPABASE_ANON_KEY!
-    );
-  }
+    async initializeSupabase() {
+      const { createClient } = await import('@supabase/supabase-js');
+      this.supabase = createClient(
+        SUPABASE_URL,
+        DANIEL_SUPABASE_ANON_KEY
+      );
+    }
 
   async searchGooglePlaces(name: string, address: string): Promise<{ place_id: string; photo_reference?: string } | null> {
     try {

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,22 +1,23 @@
 import express, { Request, Response } from 'express';
-import { config } from 'dotenv';
 import { createClient } from '@supabase/supabase-js';
 import { neon } from '@neondatabase/serverless';
-
-// Load environment variables
-config();
+import {
+  SUPABASE_URL,
+  DANIEL_SUPABASE_ANON_KEY,
+  DATABASE_URL
+} from './config';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
 // Initialize Supabase client
 const supabase = createClient(
-  process.env.SUPABASE_URL!,
-  process.env.DANIEL_SUPABASE_ANON_KEY!
+  SUPABASE_URL,
+  DANIEL_SUPABASE_ANON_KEY
 );
 
 // Initialize database connection
-const db = neon(process.env.DATABASE_URL!);
+const db = neon(DATABASE_URL);
 
 // Middleware
 app.use(express.json());
@@ -36,9 +37,9 @@ app.get('/api/health', (req: Request, res: Response) => {
 // Test environment variables
 app.get('/api/env-test', (req: Request, res: Response) => {
   const envVars = {
-    DATABASE_URL: process.env.DATABASE_URL ? 'Set' : 'Not set',
-    SUPABASE_URL: process.env.SUPABASE_URL ? 'Set' : 'Not set',
-    DANIEL_SUPABASE_ANON_KEY: process.env.DANIEL_SUPABASE_ANON_KEY ? 'Set' : 'Not set',
+    DATABASE_URL: DATABASE_URL ? 'Set' : 'Not set',
+    SUPABASE_URL: SUPABASE_URL ? 'Set' : 'Not set',
+    DANIEL_SUPABASE_ANON_KEY: DANIEL_SUPABASE_ANON_KEY ? 'Set' : 'Not set',
     GOOGLE_PLACES_API_KEY: process.env.GOOGLE_PLACES_API_KEY ? 'Set' : 'Not set',
     OPENWEATHER_API_KEY: process.env.OPENWEATHER_API_KEY ? 'Set' : 'Not set'
   };
@@ -142,8 +143,8 @@ app.get('/', (req: Request, res: Response) => {
       
       <h2>Environment:</h2>
       <p>Environment: ${process.env.NODE_ENV || 'development'}</p>
-      <p>Database: ${process.env.DATABASE_URL ? 'Connected' : 'Not configured'}</p>
-      <p>Supabase: ${process.env.SUPABASE_URL ? 'Connected' : 'Not configured'}</p>
+      <p>Database: ${DATABASE_URL ? 'Connected' : 'Not configured'}</p>
+      <p>Supabase: ${SUPABASE_URL ? 'Connected' : 'Not configured'}</p>
       <p>Google Places: ${process.env.GOOGLE_PLACES_API_KEY ? 'Configured' : 'Not configured'}</p>
     </body>
     </html>

--- a/server/photo-audit-system.ts
+++ b/server/photo-audit-system.ts
@@ -3,6 +3,8 @@
  * Ensures every destination has a valid, authentic image
  */
 
+import { DATABASE_URL } from './config';
+
 interface PhotoValidationResult {
   destinationId: string;
   name: string;
@@ -27,7 +29,7 @@ export class PhotoAuditSystem {
 
   async initializeConnection() {
     const { neon } = await import('@neondatabase/serverless');
-    this.localDb = neon(process.env.DATABASE_URL!);
+    this.localDb = neon(DATABASE_URL);
   }
 
   async runCompletePhotoAudit(limit?: number): Promise<{

--- a/server/photo-enrichment-system.ts
+++ b/server/photo-enrichment-system.ts
@@ -5,6 +5,7 @@
 
 import axios from 'axios';
 import { storage } from './storage';
+import { SUPABASE_URL, DANIEL_SUPABASE_ANON_KEY } from './config';
 
 interface GooglePlacesPhoto {
   height: number;
@@ -325,10 +326,10 @@ export class PhotoEnrichmentSystem {
     try {
       // Use Supabase directly instead of storage.query
       const { createClient } = await import('@supabase/supabase-js');
-      const supabase = createClient(
-        process.env.SUPABASE_URL!,
-        process.env.DANIEL_SUPABASE_ANON_KEY!
-      );
+        const supabase = createClient(
+          SUPABASE_URL,
+          DANIEL_SUPABASE_ANON_KEY
+        );
 
       const { count: total } = await supabase
         .from('destinations')

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -9,6 +9,7 @@ import { photoEnrichmentSystem } from './photo-enrichment-system';
 import { photoVerificationSystem } from './photo-verification';
 import express from "express";
 import { Client } from '@googlemaps/google-maps-services-js';
+import { SUPABASE_URL, DANIEL_SUPABASE_ANON_KEY } from './config';
 
 // TypeScript interfaces
 interface WeatherData {
@@ -208,19 +209,19 @@ export function registerRoutes(app: Express): Server {
   app.get("/api/destinations", async (req, res) => {
     try {
       console.log('Destinations API called');
-      console.log('Environment variables:', {
-        hasSupabaseUrl: !!process.env.SUPABASE_URL,
-        hasSupabaseKey: !!process.env.DANIEL_SUPABASE_ANON_KEY,
-        environment: process.env.NODE_ENV
-      });
+        console.log('Environment variables:', {
+          hasSupabaseUrl: !!SUPABASE_URL,
+          hasSupabaseKey: !!DANIEL_SUPABASE_ANON_KEY,
+          environment: process.env.NODE_ENV
+        });
       
       const { limit = "all", offset = "0", category, search, status = "all" } = req.query;
       const { createClient } = await import('@supabase/supabase-js');
       
-      const supabase = createClient(
-        process.env.SUPABASE_URL!,
-        process.env.DANIEL_SUPABASE_ANON_KEY!
-      );
+        const supabase = createClient(
+          SUPABASE_URL,
+          DANIEL_SUPABASE_ANON_KEY
+        );
 
       let query = supabase
         .from('destinations')
@@ -279,8 +280,8 @@ export function registerRoutes(app: Express): Server {
       const { createClient } = await import('@supabase/supabase-js');
       
       const supabase = createClient(
-        process.env.SUPABASE_URL!,
-        process.env.DANIEL_SUPABASE_ANON_KEY!
+        SUPABASE_URL,
+        DANIEL_SUPABASE_ANON_KEY
       );
 
       // Update all inactive destinations to active
@@ -347,8 +348,8 @@ export function registerRoutes(app: Express): Server {
       const { createClient } = await import('@supabase/supabase-js');
       
       const supabase = createClient(
-        process.env.SUPABASE_URL!,
-        process.env.DANIEL_SUPABASE_ANON_KEY!
+        SUPABASE_URL,
+        DANIEL_SUPABASE_ANON_KEY
       );
 
       const { data, error } = await supabase
@@ -375,8 +376,8 @@ export function registerRoutes(app: Express): Server {
       const { createClient } = await import('@supabase/supabase-js');
       
       const supabase = createClient(
-        process.env.SUPABASE_URL!,
-        process.env.DANIEL_SUPABASE_ANON_KEY!
+        SUPABASE_URL,
+        DANIEL_SUPABASE_ANON_KEY
       );
 
       let query = supabase
@@ -449,8 +450,8 @@ export function registerRoutes(app: Express): Server {
     try {
       const { createClient } = await import('@supabase/supabase-js');
       const supabase = createClient(
-        process.env.SUPABASE_URL!,
-        process.env.DANIEL_SUPABASE_ANON_KEY!
+        SUPABASE_URL,
+        DANIEL_SUPABASE_ANON_KEY
       );
 
       // Get basic stats
@@ -472,8 +473,8 @@ export function registerRoutes(app: Express): Server {
     try {
       const { createClient } = await import('@supabase/supabase-js');
       const supabase = createClient(
-        process.env.SUPABASE_URL!,
-        process.env.DANIEL_SUPABASE_ANON_KEY!
+        SUPABASE_URL,
+        DANIEL_SUPABASE_ANON_KEY
       );
 
       const { data, error } = await supabase

--- a/server/routes/amazon-affiliate.ts
+++ b/server/routes/amazon-affiliate.ts
@@ -3,11 +3,12 @@ import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import { amazonAffiliateProducts } from '../../shared/schema.js';
 import { eq, ilike, or, inArray } from 'drizzle-orm';
+import { DATABASE_URL } from '../config';
 
 const router = Router();
 
 // Initialize database connection
-const connectionString = process.env.DATABASE_URL;
+const connectionString = DATABASE_URL;
 const sql = postgres(connectionString || '');
 const db = drizzle(sql);
 

--- a/server/routes/destinations.ts
+++ b/server/routes/destinations.ts
@@ -3,14 +3,12 @@ import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import { destinations } from '../../shared/schema.js';
 import { eq, ilike, or, desc, asc } from 'drizzle-orm';
+import { DATABASE_URL } from '../config';
 
 const router = Router();
 
 // Database connection
-const connectionString = process.env.DATABASE_URL;
-if (!connectionString) {
-  throw new Error('DATABASE_URL environment variable is required');
-}
+const connectionString = DATABASE_URL;
 
 const client = postgres(connectionString);
 const db = drizzle(client);

--- a/server/routes/tripkits.ts
+++ b/server/routes/tripkits.ts
@@ -3,15 +3,12 @@ import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import { trip_kits } from '../../shared/mt-olympus-schema.js';
 import { eq, ilike, or, desc, asc } from 'drizzle-orm';
+import { DATABASE_URL } from '../config';
 
 const router = Router();
 
 // Database connection
-const connectionString = process.env.DATABASE_URL;
-if (!connectionString) {
-  throw new Error('DATABASE_URL environment variable is required');
-}
-
+const connectionString = DATABASE_URL;
 const client = postgres(connectionString);
 const db = drizzle(client);
 

--- a/server/schema-inspector.ts
+++ b/server/schema-inspector.ts
@@ -5,6 +5,7 @@
  */
 
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL, DANIEL_SUPABASE_ANON_KEY } from './config';
 
 interface ColumnInfo {
   column_name: string;
@@ -25,16 +26,16 @@ export class SchemaInspector {
 
   constructor() {
     // Main Supabase instance
-    this.supabase = createClient(
-      process.env.SUPABASE_URL!,
-      process.env.SUPABASE_ANON_KEY!
-    );
+      this.supabase = createClient(
+        SUPABASE_URL,
+        process.env.SUPABASE_ANON_KEY!
+      );
 
     // Daniel's database instance
-    this.danielSupabase = createClient(
-      process.env.SUPABASE_URL!,
-      process.env.DANIEL_SUPABASE_ANON_KEY!
-    );
+      this.danielSupabase = createClient(
+        SUPABASE_URL,
+        DANIEL_SUPABASE_ANON_KEY
+      );
   }
 
   /**

--- a/server/services/affiliate-tracking.ts
+++ b/server/services/affiliate-tracking.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL } from '../config';
 
 interface AffiliateClick {
   id: string;
@@ -35,11 +36,11 @@ class AffiliateTrackingService {
   private supabase: any;
   private sessionId: string;
 
-  constructor() {
-    this.supabase = createClient(
-      process.env.SUPABASE_URL!,
-      process.env.SUPABASE_ANON_KEY!
-    );
+    constructor() {
+      this.supabase = createClient(
+        SUPABASE_URL,
+        process.env.SUPABASE_ANON_KEY!
+      );
     this.sessionId = this.generateSessionId();
   }
 

--- a/server/services/ai-recommendations.ts
+++ b/server/services/ai-recommendations.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL } from '../config';
 
 interface GearRecommendation {
   id: string;
@@ -36,11 +37,11 @@ class AIRecommendationService {
   private golfnowPartnerId: string;
   private turoAffiliateId: string;
 
-  constructor() {
-    this.supabase = createClient(
-      process.env.SUPABASE_URL!,
-      process.env.SUPABASE_ANON_KEY!
-    );
+    constructor() {
+      this.supabase = createClient(
+        SUPABASE_URL,
+        process.env.SUPABASE_ANON_KEY!
+      );
     this.amazonTag = process.env.AMAZON_ASSOCIATES_TAG || '';
     this.viatorAffiliateId = process.env.VIATOR_AFFILIATE_ID || '';
     this.golfnowPartnerId = process.env.GOLFNOW_PARTNER_ID || '';

--- a/server/services/commission-tracking.ts
+++ b/server/services/commission-tracking.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL } from '../config';
 
 interface CommissionRecord {
   id: string;
@@ -48,11 +49,11 @@ class CommissionTrackingService {
   private supabase: any;
   private commissionRates: { [key: string]: number };
 
-  constructor() {
-    this.supabase = createClient(
-      process.env.SUPABASE_URL!,
-      process.env.SUPABASE_ANON_KEY!
-    );
+    constructor() {
+      this.supabase = createClient(
+        SUPABASE_URL,
+        process.env.SUPABASE_ANON_KEY!
+      );
     
     this.commissionRates = {
       viator: parseFloat(process.env.COMMISSION_RATE_VIATOR || '0.08'),

--- a/server/services/inventory-sync.ts
+++ b/server/services/inventory-sync.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL } from '../config';
 
 interface InventoryItem {
   id: string;
@@ -33,7 +34,7 @@ class InventorySyncService {
 
   constructor() {
     this.supabase = createClient(
-      process.env.SUPABASE_URL!,
+      SUPABASE_URL,
       process.env.SUPABASE_ANON_KEY!
     );
   }

--- a/server/sql-photo-sync.ts
+++ b/server/sql-photo-sync.ts
@@ -3,6 +3,8 @@
  * Direct database connection to pull authentic Unsplash photos
  */
 
+import { DATABASE_URL } from './config';
+
 export class SqlPhotoSync {
   private localDb: any;
   private processed: number = 0;
@@ -12,7 +14,7 @@ export class SqlPhotoSync {
 
   async initializeConnection() {
     const { neon } = await import('@neondatabase/serverless');
-    this.localDb = neon(process.env.DATABASE_URL!);
+    this.localDb = neon(DATABASE_URL);
   }
 
   async syncAuthenticPhotos(limit?: number): Promise<{

--- a/server/supabase-api-sync.ts
+++ b/server/supabase-api-sync.ts
@@ -1,5 +1,6 @@
 import { db } from './db';
 import { destinations } from '@shared/schema';
+import { SUPABASE_URL } from './config';
 
 interface SupabaseDestination {
   id: number;
@@ -99,13 +100,13 @@ function mapSupabaseToDestination(supabaseDest: SupabaseDestination) {
 export async function syncSupabaseDestinationsAPI() {
   // console.log('🔄 Starting Supabase API sync...');
 
-  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_ANON_KEY) {
+  if (!process.env.SUPABASE_ANON_KEY) {
     throw new Error('Supabase credentials not available');
   }
 
   try {
     // Fetch from the destinations table
-    const response = await fetch(`${process.env.SUPABASE_URL}/rest/v1/destinations?select=*`, {
+    const response = await fetch(`${SUPABASE_URL}/rest/v1/destinations?select=*`, {
       headers: {
         'apikey': process.env.SUPABASE_ANON_KEY,
         'Authorization': `Bearer ${process.env.SUPABASE_ANON_KEY}`,

--- a/server/supabase-client.ts
+++ b/server/supabase-client.ts
@@ -4,18 +4,12 @@
  */
 
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL } from './config';
 
 // Use environment variables only
-const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY;
 
 // Provide better error messages for missing environment variables
-if (!SUPABASE_URL) {
-  // console.error('❌ SUPABASE_URL environment variable is not set');
-  // console.error('Please check your .env file or environment configuration');
-  // Don't throw immediately, allow the app to start with limited functionality
-}
-
 if (!SUPABASE_ANON_KEY) {
   // console.error('❌ SUPABASE_ANON_KEY environment variable is not set');
   // console.error('Please check your .env file or environment configuration');

--- a/server/supabase-db.ts
+++ b/server/supabase-db.ts
@@ -1,16 +1,13 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from '../shared/supabase-types';
-
-if (!process.env.SUPABASE_URL) {
-  throw new Error("SUPABASE_URL must be set");
-}
+import { SUPABASE_URL } from './config';
 
 if (!process.env.SUPABASE_ANON_KEY) {
   throw new Error("SUPABASE_ANON_KEY must be set");
 }
 
 export const supabase = createClient<Database>(
-  process.env.SUPABASE_URL,
+  SUPABASE_URL,
   process.env.SUPABASE_ANON_KEY,
   {
     auth: {

--- a/server/supabase-direct-sync.ts
+++ b/server/supabase-direct-sync.ts
@@ -2,6 +2,7 @@ import pg from 'pg';
 const { Pool } = pg;
 import { db } from './db';
 import { destinations } from '@shared/schema';
+import { DATABASE_URL } from './config';
 
 interface SupabaseDestination {
   uuid: string;
@@ -123,7 +124,7 @@ export async function syncSupabaseDestinationsDirect() {
   // console.log('🔄 Starting direct Supabase PostgreSQL sync...');
   
   const supabasePool = new Pool({
-    connectionString: process.env.DATABASE_URL || 'postgresql://postgres:2025willbegreat!@db.unkfswfemslaeuqaxijg.supabase.co:5432/postgres',
+    connectionString: DATABASE_URL,
     ssl: { rejectUnauthorized: false }
   });
 

--- a/server/supabase-full-sync.ts
+++ b/server/supabase-full-sync.ts
@@ -7,9 +7,7 @@ import { createClient } from '@supabase/supabase-js';
 import { db } from './db';
 import { destinations } from '@shared/schema';
 import { eq } from 'drizzle-orm';
-
-const supabaseUrl = process.env.SUPABASE_URL || '';
-const supabaseKey = process.env.DANIEL_SUPABASE_ANON_KEY || '';
+import { SUPABASE_URL, DANIEL_SUPABASE_ANON_KEY } from './config';
 
 export interface SupabaseDestination {
   id: string;
@@ -56,7 +54,7 @@ export class SupabaseFullSync {
   private errors: string[] = [];
 
   constructor() {
-    this.supabase = createClient(supabaseUrl, supabaseKey);
+    this.supabase = createClient(SUPABASE_URL, DANIEL_SUPABASE_ANON_KEY);
   }
 
   /**

--- a/server/test-coordinates.ts
+++ b/server/test-coordinates.ts
@@ -1,7 +1,8 @@
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL } from './config';
 
 const supabase = createClient(
-  process.env.SUPABASE_URL!,
+  SUPABASE_URL,
   process.env.SUPABASE_ANON_KEY!
 );
 

--- a/server/verify-coords.js
+++ b/server/verify-coords.js
@@ -1,7 +1,8 @@
-const { createClient } = require('@supabase/supabase-js');
+import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL } from './config';
 
 const supabase = createClient(
-  process.env.SUPABASE_URL,
+  SUPABASE_URL,
   process.env.SUPABASE_ANON_KEY
 );
 


### PR DESCRIPTION
## Summary
- add `server/config.ts` to validate required environment variables
- use centralized env values across server modules
- remove direct `process.env` access for Supabase and database URLs

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: 631 errors, 904 warnings)*
- `npm run type-check` *(fails: type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b89409849c832dbfe88c2c3336462f