### PR TITLE
Prefer Daniel Supabase credential variables

### DIFF
--- a/env.template
+++ b/env.template
@@ -10,6 +10,8 @@
 SUPABASE_URL="https://your-project.supabase.co"
 SUPABASE_ANON_KEY="your-supabase-anon-key"
 SUPABASE_SERVICE_ROLE_KEY="your-supabase-service-role-key"
+DANIEL_SUPABASE_ANON_KEY="your-daniel-supabase-anon-key"
+DANIEL_SUPABASE_SERVICE_ROLE_KEY="your-daniel-supabase-service-role-key"
 
 # Database URL (PostgreSQL)
 DATABASE_URL="postgresql://username:password@host:port/database"

--- a/server/schema-inspector.ts
+++ b/server/schema-inspector.ts
@@ -6,6 +6,10 @@
 
 import { createClient } from '@supabase/supabase-js';
 
+const supabaseUrl = process.env.SUPABASE_URL;
+const preferredAnonKey = process.env.DANIEL_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
+const danielAnonKey = process.env.DANIEL_SUPABASE_ANON_KEY || preferredAnonKey;
+
 interface ColumnInfo {
   column_name: string;
   data_type: string;
@@ -26,14 +30,14 @@ export class SchemaInspector {
   constructor() {
     // Main Supabase instance
     this.supabase = createClient(
-      process.env.SUPABASE_URL!,
-      process.env.SUPABASE_ANON_KEY!
+      supabaseUrl!,
+      preferredAnonKey!
     );
 
     // Daniel's database instance
     this.danielSupabase = createClient(
-      process.env.SUPABASE_URL!,
-      process.env.DANIEL_SUPABASE_ANON_KEY!
+      supabaseUrl!,
+      danielAnonKey!
     );
   }
 

--- a/server/services/affiliate-tracking.ts
+++ b/server/services/affiliate-tracking.ts
@@ -1,5 +1,8 @@
 import { createClient } from '@supabase/supabase-js';
 
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseAnonKey = process.env.DANIEL_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
+
 interface AffiliateClick {
   id: string;
   tripkit_id?: string;
@@ -37,8 +40,8 @@ class AffiliateTrackingService {
 
   constructor() {
     this.supabase = createClient(
-      process.env.SUPABASE_URL!,
-      process.env.SUPABASE_ANON_KEY!
+      supabaseUrl!,
+      supabaseAnonKey!
     );
     this.sessionId = this.generateSessionId();
   }

--- a/server/services/ai-recommendations.ts
+++ b/server/services/ai-recommendations.ts
@@ -1,5 +1,8 @@
 import { createClient } from '@supabase/supabase-js';
 
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseAnonKey = process.env.DANIEL_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
+
 interface GearRecommendation {
   id: string;
   name: string;
@@ -38,8 +41,8 @@ class AIRecommendationService {
 
   constructor() {
     this.supabase = createClient(
-      process.env.SUPABASE_URL!,
-      process.env.SUPABASE_ANON_KEY!
+      supabaseUrl!,
+      supabaseAnonKey!
     );
     this.amazonTag = process.env.AMAZON_ASSOCIATES_TAG || '';
     this.viatorAffiliateId = process.env.VIATOR_AFFILIATE_ID || '';

--- a/server/services/commission-tracking.ts
+++ b/server/services/commission-tracking.ts
@@ -1,5 +1,8 @@
 import { createClient } from '@supabase/supabase-js';
 
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseAnonKey = process.env.DANIEL_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
+
 interface CommissionRecord {
   id: string;
   click_id: string;
@@ -50,8 +53,8 @@ class CommissionTrackingService {
 
   constructor() {
     this.supabase = createClient(
-      process.env.SUPABASE_URL!,
-      process.env.SUPABASE_ANON_KEY!
+      supabaseUrl!,
+      supabaseAnonKey!
     );
     
     this.commissionRates = {

--- a/server/services/inventory-sync.ts
+++ b/server/services/inventory-sync.ts
@@ -1,5 +1,8 @@
 import { createClient } from '@supabase/supabase-js';
 
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseAnonKey = process.env.DANIEL_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
+
 interface InventoryItem {
   id: string;
   vendor: string;
@@ -33,8 +36,8 @@ class InventorySyncService {
 
   constructor() {
     this.supabase = createClient(
-      process.env.SUPABASE_URL!,
-      process.env.SUPABASE_ANON_KEY!
+      supabaseUrl!,
+      supabaseAnonKey!
     );
   }
 

--- a/server/supabase-api-sync.ts
+++ b/server/supabase-api-sync.ts
@@ -1,6 +1,9 @@
 import { db } from './db';
 import { destinations } from '@shared/schema';
 
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseAnonKey = process.env.DANIEL_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
+
 interface SupabaseDestination {
   id: number;
   name: string;
@@ -99,16 +102,16 @@ function mapSupabaseToDestination(supabaseDest: SupabaseDestination) {
 export async function syncSupabaseDestinationsAPI() {
   // console.log('🔄 Starting Supabase API sync...');
 
-  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_ANON_KEY) {
+  if (!supabaseUrl || !supabaseAnonKey) {
     throw new Error('Supabase credentials not available');
   }
 
   try {
     // Fetch from the destinations table
-    const response = await fetch(`${process.env.SUPABASE_URL}/rest/v1/destinations?select=*`, {
+    const response = await fetch(`${supabaseUrl}/rest/v1/destinations?select=*`, {
       headers: {
-        'apikey': process.env.SUPABASE_ANON_KEY,
-        'Authorization': `Bearer ${process.env.SUPABASE_ANON_KEY}`,
+        'apikey': supabaseAnonKey,
+        'Authorization': `Bearer ${supabaseAnonKey}`,
         'Content-Type': 'application/json'
       }
     });

--- a/server/supabase-client.ts
+++ b/server/supabase-client.ts
@@ -7,7 +7,8 @@ import { createClient } from '@supabase/supabase-js';
 
 // Use environment variables only
 const SUPABASE_URL = process.env.SUPABASE_URL;
-const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY;
+const SUPABASE_ANON_KEY = process.env.DANIEL_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.DANIEL_SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 // Provide better error messages for missing environment variables
 if (!SUPABASE_URL) {
@@ -23,15 +24,15 @@ if (!SUPABASE_ANON_KEY) {
 }
 
 // Create Supabase client only if both variables are available
-export const supabase = SUPABASE_URL && SUPABASE_ANON_KEY 
+export const supabase = SUPABASE_URL && SUPABASE_ANON_KEY
   ? createClient(SUPABASE_URL, SUPABASE_ANON_KEY)
   : null;
 
 // Service role client for admin operations - use service role key for writes
-export const supabaseAdmin = (SUPABASE_URL && process.env.SUPABASE_SERVICE_ROLE_KEY)
+export const supabaseAdmin = (SUPABASE_URL && SUPABASE_SERVICE_ROLE_KEY)
   ? createClient(
       SUPABASE_URL,
-      process.env.SUPABASE_SERVICE_ROLE_KEY,
+      SUPABASE_SERVICE_ROLE_KEY,
       {
         auth: {
           autoRefreshToken: false,
@@ -39,7 +40,7 @@ export const supabaseAdmin = (SUPABASE_URL && process.env.SUPABASE_SERVICE_ROLE_
         }
       }
     )
-  : (SUPABASE_URL && SUPABASE_ANON_KEY) 
+  : (SUPABASE_URL && SUPABASE_ANON_KEY)
     ? createClient(SUPABASE_URL, SUPABASE_ANON_KEY)
     : null;
 

--- a/server/supabase-db.ts
+++ b/server/supabase-db.ts
@@ -1,17 +1,20 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from '../shared/supabase-types';
 
-if (!process.env.SUPABASE_URL) {
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseAnonKey = process.env.DANIEL_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
+
+if (!supabaseUrl) {
   throw new Error("SUPABASE_URL must be set");
 }
 
-if (!process.env.SUPABASE_ANON_KEY) {
-  throw new Error("SUPABASE_ANON_KEY must be set");
+if (!supabaseAnonKey) {
+  throw new Error("DANIEL_SUPABASE_ANON_KEY or SUPABASE_ANON_KEY must be set");
 }
 
 export const supabase = createClient<Database>(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_ANON_KEY,
+  supabaseUrl,
+  supabaseAnonKey,
   {
     auth: {
       persistSession: false,

--- a/server/test-coordinates.ts
+++ b/server/test-coordinates.ts
@@ -1,8 +1,11 @@
 import { createClient } from '@supabase/supabase-js';
 
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseAnonKey = process.env.DANIEL_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
+
 const supabase = createClient(
-  process.env.SUPABASE_URL!,
-  process.env.SUPABASE_ANON_KEY!
+  supabaseUrl!,
+  supabaseAnonKey!
 );
 
 async function verifyCoordinates() {

--- a/server/verify-coords.js
+++ b/server/verify-coords.js
@@ -1,8 +1,11 @@
 const { createClient } = require('@supabase/supabase-js');
 
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseAnonKey = process.env.DANIEL_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
+
 const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_ANON_KEY
+  supabaseUrl,
+  supabaseAnonKey
 );
 
 async function verifyCoordinates() {


### PR DESCRIPTION
## Summary
- surface the DANIEL Supabase anon and service role keys in the env template
- update the shared Supabase clients (and dependent service helpers) to prefer DANIEL_SUPABASE_* with legacy fallbacks
- keep auxiliary scripts aligned so consumers consistently resolve the Daniel key path

## Testing
- `curl -sS http://localhost:4000/api/supabase-test` *(fails with dummy credentials but exercises the new env path)*
- `node --import tsx --input-type=module <<'TS' …` *(invokes /api/destinations with dummy credentials and confirms the client instantiates)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ca22cbb0832dbeb43e05eb0ab9e1